### PR TITLE
V1.12

### DIFF
--- a/DNS_Inventory_V1.ps1
+++ b/DNS_Inventory_V1.ps1
@@ -10,7 +10,9 @@
 .DESCRIPTION
 	Creates an inventory of Microsoft DNS using Microsoft Word, PDF, formatted text or HTML.
 	Creates a document named DNS.docx (or .PDF or .TXT or .HTML).
+	
 	Word and PDF documents include a Cover Page, Table of Contents and Footer.
+	
 	Includes support for the following language versions of Microsoft Word:
 		Catalan
 		Chinese
@@ -39,6 +41,27 @@
 	Remote Server Administration Tools for Windows 10
 		http://www.microsoft.com/en-us/download/details.aspx?id=45520
 		
+.PARAMETER HTML
+	Creates an HTML file with an .html extension.
+	This parameter is disabled by default.
+.PARAMETER MSWord
+	SaveAs DOCX file
+	This parameter is set True if no other output format is selected.
+.PARAMETER PDF
+	SaveAs PDF file instead of DOCX file.
+	This parameter is disabled by default.
+	The PDF file is roughly 5X to 10X larger than the DOCX file.
+	This parameter requires Microsoft Word to be installed.
+	This parameter uses the Word SaveAs PDF capability.
+.PARAMETER Text
+	Creates a formatted text file with a .txt extension.
+	This parameter is disabled by default.
+.PARAMETER AddDateTime
+	Adds a date time stamp to the end of the file name.
+	Time stamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be DomainName_DNS_2020-06-01_1800.docx (or .pdf).
+	This parameter is disabled by default.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.
 	
@@ -90,6 +113,13 @@
 	
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CPh.
+.PARAMETER ComputerName
+	Specifies a computer to use to run the script against.
+	ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+	If entered as localhost, the actual computer name is determined and used.
+	If entered as an IP address, an attempt is made to determine and use the actual 
+	computer name.
+	Default is localhost.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
 	Only Word 2010, 2013 and 2016 are supported.
@@ -138,41 +168,35 @@
 	Default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
+.PARAMETER Details
+	Include Resource Record data for both Forward and Reverse lookup zones.
+	
+	Using this parameter can create an extremely large report.
+	
+	Default is to not include Resource Record information.
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	Text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	Text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
 .PARAMETER UserName
 	User name to use for the Cover Page and Footer.
 	Default value is contained in $env:username
 	This parameter has an alias of UN.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER HTML
-	Creates an HTML file with an .html extension.
-	This parameter is disabled by default.
-.PARAMETER MSWord
-	SaveAs DOCX file
-	This parameter is set True if no other output format is selected.
-.PARAMETER PDF
-	SaveAs PDF file instead of DOCX file.
-	This parameter is disabled by default.
-	The PDF file is roughly 5X to 10X larger than the DOCX file.
-	This parameter requires Microsoft Word to be installed.
-	This parameter uses the Word SaveAs PDF capability.
-.PARAMETER Text
-	Creates a formatted text file with a .txt extension.
-	This parameter is disabled by default.
-.PARAMETER AddDateTime
-	Adds a date time stamp to the end of the file name.
-	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2018 at 6PM is 2018-06-01_1800.
-	Output filename will be DomainName_DNS_2018-06-01_1800.docx (or .pdf).
-	This parameter is disabled by default.
-.PARAMETER ComputerName
-	Specifies a computer to use to run the script against.
-	ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-	If entered as localhost, the actual computer name is determined and used.
-	If entered as an IP address, an attempt is made to determine and use the actual 
-	computer name.
-	Default is localhost.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
 .PARAMETER SmtpServer
 	Specifies the optional email server to send the output report. 
 .PARAMETER SmtpPort
@@ -187,25 +211,6 @@
 .PARAMETER To
 	Specifies the username for the To email address.
 	If SmtpServer is used, this is a required parameter.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	Text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	Text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER Details
-	Include Resource Record data for both Forward and Reverse lookup zones.
-	Default is to not include Resource Record information.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
 .EXAMPLE
 	PS C:\PSScript > .\DNS_Inventory.ps1
 	
@@ -302,8 +307,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	July 25, 2018 at 6PM is 2018-07-25_1800.
-	Output filename will be DomainName_DNS_2018-07-25_1800.docx
+	July 25, 2020 at 6PM is 2020-07-25_1800.
+	Output filename will be DomainName_DNS_2020-07-25_1800.docx
 .EXAMPLE
 	PS C:\PSScript > .\DNS_Inventory.ps1 -PDF -AddDateTime
 	
@@ -319,8 +324,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	July 25, 2018 at 6PM is 2018-07-25_1800.
-	Output filename will be DomainName_DNS_2018-07-25_1800.PDF
+	July 25, 2020 at 6PM is 2020-07-25_1800.
+	Output filename will be DomainName_DNS_2020-07-25_1800.PDF
 .EXAMPLE
 	PS C:\PSScript > .\DNS_Inventory.ps1 -Folder \\FileServer\ShareName
 	
@@ -397,7 +402,7 @@
 	NAME: DNS_Inventory.ps1
 	VERSION: 1.12
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: December 5, 2019
+	LASTEDIT: December 6, 2019
 #>
 
 #endregion
@@ -407,6 +412,25 @@
 [CmdletBinding(SupportsShouldProcess = $False, ConfirmImpact = "None", DefaultParameterSetName = "Word") ]
 
 Param(
+	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$HTML=$False,
+
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$MSWord=$False,
+
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$PDF=$False,
+
+	[parameter(ParameterSetName="Text",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Switch]$Text=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$AddDateTime=$False,
+	
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
@@ -442,6 +466,9 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CompanyPhone="",
     
+	[parameter(Mandatory=$False)] 
+	[string]$ComputerName="LocalHost",
+
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
@@ -449,6 +476,22 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
+	[parameter(Mandatory=$False)] 
+	[Switch]$Details=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Dev=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
+	
 	[parameter(ParameterSetName="Word",Mandatory=$False)] 
 	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
@@ -456,31 +499,6 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$UserName=$env:username,
 
-	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$HTML=$False,
-
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$MSWord=$False,
-
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$PDF=$False,
-
-	[parameter(ParameterSetName="Text",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Switch]$Text=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Switch]$AddDateTime=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$ComputerName="LocalHost",
-
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
 	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
 	[string]$SmtpServer="",
 
@@ -494,38 +512,27 @@ Param(
 	[string]$From="",
 
 	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
-	[string]$To="",
+	[string]$To=""
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Details=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False
-	
 	)
 #endregion
 
 #region script change log	
-#Created by Carl Webster
+#Created by Carl Webster and Michael B. Smith
 #webster@carlwebster.com
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 #Created on February 10, 2016
 #Version 1.00 released to the community on July 25, 2016
 
-#Version 1.12 
+#Version 1.12 6-Dec-2019
 #	Fixed text string "Use root hint if no forwarders are available" to "Use root hints if no forwarders are available"
 #	Fixed spacing error in Text output for "Use root hints if no forwarders are available"
 #	For Name Servers, if the IP Address is Null or Empty, use "Unable to retrieve an IP Address"
 #		For Word/PDF and HTML output put the invalid Name Server and "Unable to retrieve an IP Address" in Red
 #		For Text output use "***Unable to retrieve an IP Address***"
+#	Reorder parameters
+#	Update help text
 #
 #Version 1.11 25-Oct-2019
 #	Fixed the sorting of Root Hint servers thanks to MBS

--- a/DNS_Inventory_V1_ReadMe.rtf
+++ b/DNS_Inventory_V1_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -93,13 +93,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid730732
 \rsid1120917\rsid2106581\rsid2388112\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid5177570\rsid5384286\rsid6634568\rsid7933527\rsid8261032\rsid8337971\rsid8814015\rsid9460937\rsid9517698\rsid9531606\rsid9844446\rsid10243667
-\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14365751\rsid14697282\rsid14893653\rsid15008361\rsid15343936
-\rsid15549553\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2019\mo10\dy25\hr9\min20}{\version30}{\edmins183}{\nofpages13}{\nofwords3969}{\nofchars22628}{\nofcharsws26544}{\vern115}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14697282\rsid14893653\rsid15008361
+\rsid15343936\rsid15549553\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2019\mo12\dy5\hr12\min42}{\version31}{\edmins185}{\nofpages13}{\nofwords3965}{\nofchars22603}{\nofcharsws26515}{\vern117}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NbE0NzA3NDWwMDE1NDVX0lEKTi0uzszPAykwqgUAYjWJIiwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NbE0NzA3NDWwMDE1NDVX0lEKTi0uzszPAykwrgUAIwSSOywAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -207,12 +207,12 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e0000000020}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -220,8 +220,9 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
-\hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for \hich\af43\dbch\af31505\loch\f43 Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c000908000038000000000047}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for\hich\af43\dbch\af31505\loch\f43  Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 4.\tab}\hich\af37\dbch\af31505\loch\f37 The D}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 
@@ -232,7 +233,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37  server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and PowerShell Version }{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid2388112 \hich\af37\dbch\af31505\loch\f37 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 .0.  The script was run on Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 8.1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 with RSAT, Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 
-\hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and PowerSh\hich\af37\dbch\af31505\loch\f37 ell 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 
+\hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and PowerS\hich\af37\dbch\af31505\loch\f37 hell 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 
 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8261032 \hich\af37\dbch\af31505\loch\f37 and}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 \hich\af37\dbch\af31505\loch\f37 
  Windows 10 with RSAT, Word 2013 and PowerShell 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -552,21 +553,21 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                 \hich\af2\dbch\af31505\loch\f2    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to\hich\af2\dbch\af31505\loch\f2  the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the\hich\af2\dbch\af31505\loch\f2  end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 
  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
@@ -574,7 +575,7 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -714,17 +715,19 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DNS_Inventory.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5177570 \hich\af2\dbch\af31505\loch\f2         VERSION: 1.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10501518 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5177570 \hich\af2\dbch\af31505\loch\f2         VERSION: 1.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8261032\charrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster - Sr. Solutions Architect - Choice Solutions, L\hich\af2\dbch\af31505\loch\f2 LC
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10501518 \hich\af2\dbch\af31505\loch\f2 October 25, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 and Michael B. Smith}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
+
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 December }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10501518 \hich\af2\dbch\af31505\loch\f2 5, 2019}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="\hich\af2\dbch\af31505\loch\f2 Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNam\hich\af2\dbch\af31505\loch\f2 e="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -878,16 +881,16 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5177570 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030065}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid8261032\charrsid8337971 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.t\hich\af2\dbch\af31505\loch\f2 ld -ComputerName Server01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.\hich\af2\dbch\af31505\loch\f2 tld -ComputerName Server01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8261032 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:us\hich\af2\dbch\af31505\loch\f2 ername = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:u\hich\af2\dbch\af31505\loch\f2 sername = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -895,50 +898,50 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DNS server Server01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld,\hich\af2\dbch\af31505\loch\f2  sending from XDAdmin@domain.tld, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld\hich\af2\dbch\af31505\loch\f2 , sending from XDAdmin@domain.tld, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 sending to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 ITGroup@domain.tld.
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
 \par \hich\af2\dbch\af31505\loch\f2     t}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid creden\hich\af2\dbch\af31505\loch\f2 tials.
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer smtp.of\hich\af2\dbch\af31505\loch\f2 fice365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebs\hich\af2\dbch\af31505\loch\f2 ter.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     Script will u\hich\af2\dbch\af31505\loch\f2 se the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
 \par \hich\af2\dbch\af31505\loch\f2     t}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid credentials.
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid cre\hich\af2\dbch\af31505\loch\f2 dentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\DNS_Inventory.ps1 -Details
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -Details
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Webste\hich\af2\dbch\af31505\loch\f2 r" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Includes details for all Resource Records for both Forward and Reverse lookup zones.
+\par \hich\af2\dbch\af31505\loch\f2     Include\hich\af2\dbch\af31505\loch\f2 s details for all Resource Records for both Forward and Reverse lookup zones.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15343936\charrsid15343936 
@@ -1061,8 +1064,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000050c3
-f26b3f8bd501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000040e5
+cfc39babd501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DNS_Inventory_V1_ReadMe.rtf
+++ b/DNS_Inventory_V1_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -93,9 +93,9 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid730732
 \rsid1120917\rsid2106581\rsid2388112\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid5177570\rsid5384286\rsid6634568\rsid7933527\rsid8261032\rsid8337971\rsid8814015\rsid9460937\rsid9517698\rsid9531606\rsid9844446\rsid10243667
-\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14697282\rsid14893653\rsid15008361
-\rsid15343936\rsid15549553\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2019\mo12\dy5\hr12\min42}{\version31}{\edmins185}{\nofpages13}{\nofwords3965}{\nofchars22603}{\nofcharsws26515}{\vern117}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12457768\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14697282\rsid14893653
+\rsid15008361\rsid15343936\rsid15549553\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy6\hr6\min39}{\version32}{\edmins191}{\nofpages14}{\nofwords3983}{\nofchars22707}{\nofcharsws26637}{\vern117}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -207,12 +207,13 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f4e}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
+\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296"\hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a004e}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -220,7 +221,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c000908000038000000000047}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000477f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for\hich\af43\dbch\af31505\loch\f43  Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -284,61 +285,67 @@ Help Text
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 PS C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 > get-help .\\DNS_Inventory_V1.ps1 -full
 \par 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid12457768 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 PS }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 > get-help .\\DNS_Inventory_V1.ps1 -full
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
 DNS_Inventory_V1.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsoft Word, PDF, form\hich\af2\dbch\af31505\loch\f2 atted text or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsoft Word, PDF, formatted text or HTML.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
-DNS_Inventory_V1.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-MSWord] [-\hich\af2\dbch\af31505\loch\f2 
-AddDateTime] [-ComputerName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String>] [-Folder <String>] [-Dev] [-ScriptInfo] [-Details] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
+DNS_Inventory_V1.ps1 [-MSWord] [-AddDateTime] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <Str\hich\af2\dbch\af31505\loch\f2 
+ing>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-ComputerName <String>] [-CoverPage <String>] [-Details] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-UserName <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2    [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
-DNS_Inventory_V1.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] [-PDF] [-Text] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-ComputerName <String>] [-Folder <String>] -SmtpServer <String> }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-S\hich\af2\dbch\af31505\loch\f2 mtpPort <Int32>] [-UseSSL] -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String> -To <String> [-Dev] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-Details] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
+DNS_Inventory_V1.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-Ad\hich\af2\dbch\af31505\loch\f2 dDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-ComputerName <String>] [-CoverPage }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 <String>] [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 <\hich\af2\dbch\af31505\loch\f2 
+String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
-DNS_Inventory_V1.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <St\hich\af2\dbch\af31505\loch\f2 
-ring>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-PDF] [-AddDateTime] [-ComputerName }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 <String>] [-Folder <String>] [-Dev] [-ScriptInfo] [-Details] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
+DNS_Inventory_V1.ps1 [-HTML] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [<Co\hich\af2\dbch\af31505\loch\f2 mmonParameters>]
+
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
-DNS_Inventory_V1.ps1 [\hich\af2\dbch\af31505\loch\f2 -HTML] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Dev] [-ScriptInfo] [-Details] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
+DNS_Inventory_V1.ps1 [-PDF] [-AddDateTime] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-ComputerName <String>] [-CoverPage <String>] [-Details
+\hich\af2\dbch\af31505\loch\f2 ] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-UserName <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2     
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \\\hich\af2\dbch\af31505\loch\f2 
-DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Dev] [-ScriptInfo] [-Details] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \\\hich\af2\dbch\af31505\loch\f2 
+DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 \hich\af2\dbch\af31505\loch\f2 [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [<CommonParameters\hich\af2\dbch\af31505\loch\f2 >]
+
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsoft Word, PDF, formatted text or HT\hich\af2\dbch\af31505\loch\f2 ML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsoft Word, PDF, formatted text or HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a document named DNS.docx (or .PDF or .TXT or .HTML).
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF documents include a Cover Page, Table of Contents and Footer.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
@@ -358,47 +365,103 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=7887
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Win\hich\af2\dbch\af31505\loch\f2 dows 8
+\par \hich\af2\dbch\af31505\loch\f2     Remote Se\hich\af2\dbch\af31505\loch\f2 rver Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=28972
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=39296
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server A\hich\af2\dbch\af31505\loch\f2 dministration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=45520
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value         \hich\af2\dbch\af31505\loch\f2        False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X\hich\af2\dbch\af31505\loch\f2  to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt ext\hich\af2\dbch\af31505\loch\f2 ension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be DomainN\hich\af2\dbch\af31505\loch\f2 ame_DNS_2020-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address\hich\af2\dbch\af31505\loch\f2  field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/201\hich\af2\dbch\af31505\loch\f2 6)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipel\hich\af2\dbch\af31505\loch\f2 ine input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Fa\hich\af2\dbch\af31505\loch\f2 cet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -408,11 +471,11 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
@@ -424,37 +487,50 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 on the}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 computer running the script.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for th\hich\af2\dbch\af31505\loch\f2 e Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has\hich\af2\dbch\af31505\loch\f2  an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                 \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies a computer to use to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actua\hich\af2\dbch\af31505\loch\f2 l
+\par \hich\af2\dbch\af31505\loch\f2         computer name.
+\par \hich\af2\dbch\af31505\loch\f2         Default is localhost.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
@@ -466,151 +542,129 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 w\hich\af2\dbch\af31505\loch\f2 orks in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author \hich\af2\dbch\af31505\loch\f2 fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works \hich\af2\dbch\af31505\loch\f2 in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date d\hich\af2\dbch\af31505\loch\f2 oesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or\hich\af2\dbch\af31505\loch\f2  font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wor\hich\af2\dbch\af31505\loch\f2 d 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless change\hich\af2\dbch\af31505\loch\f2 d to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Default val\hich\af2\dbch\af31505\loch\f2 ue is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value         \hich\af2\dbch\af31505\loch\f2        Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Details [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Include Resource Record data for both Forward and Reverse lookup zones.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using this parameter can create an extremely la\hich\af2\dbch\af31505\loch\f2 rge report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Default is to not include Resource Record information.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubl\hich\af2\dbch\af31505\loch\f2 eshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the outpu\hich\af2\dbch\af31505\loch\f2 t report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Generates a l\hich\af2\dbch\af31505\loch\f2 og file for troubleshooting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Scrip\hich\af2\dbch\af31505\loch\f2 tInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only \hich\af2\dbch\af31505\loch\f2 valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This paramet\hich\af2\dbch\af31505\loch\f2 er is set True if no other output format is selected.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard chara\hich\af2\dbch\af31505\loch\f2 cters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to \hich\af2\dbch\af31505\loch\f2 be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                 \hich\af2\dbch\af31505\loch\f2    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the\hich\af2\dbch\af31505\loch\f2  end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be DomainName_DNS_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies a computer to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and us\hich\af2\dbch\af31505\loch\f2 ed.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 computer name.
-\par \hich\af2\dbch\af31505\loch\f2         Default is localhost.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value  \hich\af2\dbch\af31505\loch\f2               LocalHost
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard ch\hich\af2\dbch\af31505\loch\f2 aracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
@@ -621,23 +675,23 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServe\hich\af2\dbch\af31505\loch\f2 r.
 \par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2     -From \hich\af2\dbch\af31505\loch\f2 <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -647,97 +701,50 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer \hich\af2\dbch\af31505\loch\f2 requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Details [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Include Resource Record d\hich\af2\dbch\af31505\loch\f2 ata for both Forward and Reverse lookup zones.
-\par \hich\af2\dbch\af31505\loch\f2         Default is to not include Resource Record information.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable,\hich\af2\dbch\af31505\loch\f2  WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pi\hich\af2\dbch\af31505\loch\f2 pe objects to this script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 OUT\hich\af2\dbch\af31505\loch\f2 PUTS
+\par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
 \par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, Formatted Text or HTML document.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DNS_Inventory.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5177570 \hich\af2\dbch\af31505\loch\f2         VERSION: 1.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032\charrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 and Michael B. Smith}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
-
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14306423 \hich\af2\dbch\af31505\loch\f2 December }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10501518 \hich\af2\dbch\af31505\loch\f2 5, 2019}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.12
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: December 6, 2019
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNam\hich\af2\dbch\af31505\loch\f2 e="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softw\hich\af2\dbch\af31505\loch\f2 are\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cov\hich\af2\dbch\af31505\loch\f2 er Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Tests to see if the computer, localhost, is a DNS server.
 \par \hich\af2\dbch\af31505\loch\f2     If it is, the script runs. If not, the script aborts.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
@@ -746,7 +753,7 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Comm\hich\af2\dbch\af31505\loch\f2 on\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -755,40 +762,49 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Runs the script against the DNS server named DNS01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 3 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -TEXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for\hich\af2\dbch\af31505\loch\f2  the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -797,26 +813,36 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_Inv\hich\af2\dbch\af31505\loch\f2 entory.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -UserName "Carl Webster"
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 6 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_Inventory.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768\charrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid12457768\charrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     "Carl Web\hich\af2\dbch\af31505\loch\f2 ster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
@@ -825,72 +851,73 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     July 25, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 -0\hich\af2\dbch\af31505\loch\f2 7-25_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be DomainName_DNS_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
-\hich\af2\dbch\af31505\loch\f2 -07-25_1800.docx
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -PDF -AddDateTime
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the documen\hich\af2\dbch\af31505\loch\f2 t as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HH\hich\af2\dbch\af31505\loch\f2 mm.
-\par \hich\af2\dbch\af31505\loch\f2     July 25, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -07-25_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be DomainName_DNS_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
-\hich\af2\dbch\af31505\loch\f2 -07-25_1800.PDF
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date tim\hich\af2\dbch\af31505\loch\f2 e stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     July 25, 2020 at 6PM is 2020-07-25_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be DomainName_DNS_2020-07-25_1800.docx
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -PDF -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\User\hich\af2\dbch\af31505\loch\f2 Info\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrato\hich\af2\dbch\af31505\loch\f2 r for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     July 25, 2020 at 6PM is 2020-07-25_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be DomainName_DNS_2020-07-25_1800.PDF
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -Folder \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file is saved in the path \\\\FileServer\\ShareName
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
-\hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5177570 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030065}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid8261032\charrsid8337971 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.\hich\af2\dbch\af31505\loch\f2 tld -ComputerName Server01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8261032 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -\hich\af2\dbch\af31505\loch\f2 SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName Server01
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:u\hich\af2\dbch\af31505\loch\f2 sername = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -898,50 +925,54 @@ DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-ComputerName <String>] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DNS server Server01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld\hich\af2\dbch\af31505\loch\f2 , sending from XDAdmin@domain.tld, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 sending to}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMTP port 25 and will not use SSL.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     t}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     I\hich\af2\dbch\af31505\loch\f2 f the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer smtp.of\hich\af2\dbch\af31505\loch\f2 fice365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -SmtpServer smtp.offic\hich\af2\dbch\af31505\loch\f2 e365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12457768\charrsid12457768 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will u\hich\af2\dbch\af31505\loch\f2 se the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.offic\hich\af2\dbch\af31505\loch\f2 e365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 
-\par \hich\af2\dbch\af31505\loch\f2     t}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 \hich\af2\dbch\af31505\loch\f2 enter valid cre\hich\af2\dbch\af31505\loch\f2 dentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory.ps1 -Details
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     Wil\hich\af2\dbch\af31505\loch\f2 l use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webste\hich\af2\dbch\af31505\loch\f2 r" or
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl W\hich\af2\dbch\af31505\loch\f2 ebster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Include\hich\af2\dbch\af31505\loch\f2 s details for all Resource Records for both Forward and Reverse lookup zones.
+\par \hich\af2\dbch\af31505\loch\f2     Includes details for all Resource Records for both Forward and Reverse lookup zones.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15343936\charrsid15343936 
@@ -1064,8 +1095,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000040e5
-cfc39babd501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000e0ed
+032332acd501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DNS_Script_ChangeLog.txt
+++ b/DNS_Script_ChangeLog.txt
@@ -1,10 +1,16 @@
 #region script change log	
-#Created by Carl Webster
-#Sr. Solutions Architect, Choice Solutions, LLC
+#Created by Carl Webster and Michael B. Smith
 #webster@carlwebster.com
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 #Created on February 10, 2016
+
+#Version 1.12 6-Dec-2019
+#	Fixed text string "Use root hint if no forwarders are available" to "Use root hints if no forwarders are available"
+#	Fixed spacing error in Text output for "Use root hints if no forwarders are available"
+#	For Name Servers, if the IP Address is Null or Empty, use "Unable to retrieve an IP Address"
+#		For Word/PDF and HTML output put the invalid Name Server and "Unable to retrieve an IP Address" in Red
+#		For Text output use "***Unable to retrieve an IP Address***"
 
 #Version 1.11 25-Oct-2019
 #	Fixed the sorting of Root Hint servers thanks to MBS

--- a/DNS_Script_ChangeLog.txt
+++ b/DNS_Script_ChangeLog.txt
@@ -11,6 +11,8 @@
 #	For Name Servers, if the IP Address is Null or Empty, use "Unable to retrieve an IP Address"
 #		For Word/PDF and HTML output put the invalid Name Server and "Unable to retrieve an IP Address" in Red
 #		For Text output use "***Unable to retrieve an IP Address***"
+#	Reorder parameters
+#	Update help text
 
 #Version 1.11 25-Oct-2019
 #	Fixed the sorting of Root Hint servers thanks to MBS


### PR DESCRIPTION
#Version 1.12 6-Dec-2019
#	Fixed text string "Use root hint if no forwarders are available" to "Use root hints if no forwarders are available"
#	Fixed spacing error in Text output for "Use root hints if no forwarders are available"
#	For Name Servers, if the IP Address is Null or Empty, use "Unable to retrieve an IP Address"
#		For Word/PDF and HTML output put the invalid Name Server and "Unable to retrieve an IP Address" in Red
#		For Text output use "***Unable to retrieve an IP Address***"
#	Reorder parameters
#	Update help text