### PR TITLE
V1.21

### DIFF
--- a/DNS_Inventory_V1.ps1
+++ b/DNS_Inventory_V1.ps1
@@ -440,9 +440,9 @@
 	This script creates a Word, PDF, Formatted Text or HTML document.
 .NOTES
 	NAME: DNS_Inventory.ps1
-	VERSION: 1.20
+	VERSION: 1.21
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: February 13, 2020
+	LASTEDIT: February 14, 2020
 #>
 
 #endregion
@@ -569,6 +569,9 @@ Param(
 #Created on February 10, 2016
 #Version 1.00 released to the community on July 25, 2016
 
+#Version 1.21
+#	Fixed cases where no root hint servers were in the report or all the root hint servers were duplicated (MBS)
+
 #Version 1.20 13-Feb-2020
 #	Added -AllDNSServers (ALL) parameter to process all AD DNS servers that are online
 #		Added text file (BadDNSServers_yyyy-MM-dd_HHmm.txt) of the AD DNS servers that 
@@ -664,7 +667,7 @@ Param(
 #endregion
 
 #region initial variable testing and setup
-Set-StrictMode -Version 2
+Set-StrictMode -Version Latest
 
 #force  on
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
@@ -3864,14 +3867,43 @@ Function OutputDNSServer
 	#$RootHints = $RootHints | Sort-Object $RootHints.NameServer.RecordData.NameServer
 	
 	#V1.11 Thanks to MBS, Root Hint servers are now sorted
+	#$global:saveRootHints = $RootHints
+	#V1.21 MBS fixed cases where no root hint servers were in the report or all the root hint servers were duplicated
 	$RHs = $( foreach( $r in $RootHints ) {
-	[PsCustomObject]@{ 
-	NameServer = $r.ipaddress.hostname; 
-	IPAddresss = if( $r.IPAddress.RecordType -eq 'AAAA' ) { $r.IPAddress.RecordData.IPv6Address } else { $r.IPAddress.recorddata.IPv4Address } 
-	}
-		} 
+			if( $r -is [Array] )
+			{
+				foreach( $i in $r )
+				{
+					[PsCustomObject] @{
+						NameServer = $i.ipaddress.hostname; 
+						IPAddresss = if( $i.IPAddress.RecordType -eq 'AAAA' ) { $i.IPAddress.RecordData.IPv6Address } else { $i.IPAddress.recorddata.IPv4Address } 
+					}	
+				}
+			}
+			else
+			{
+				if( $r.IPAddress -is [Array] )
+				{
+					foreach( $i in $r.IPAddress )
+					{
+						[PsCustomObject] @{
+							NameServer = $i.hostname; 
+							IPAddresss = if( $i.RecordType -eq 'AAAA' ) { $i.RecordData.IPv6Address } else { $i.RecordData.IPv4Address } 
+						}	
+					}	
+				}
+				else
+				{
+					[PsCustomObject] @{
+						NameServer = $r.ipaddress.hostname; 
+						IPAddresss = if( $r.IPAddress.RecordType -eq 'AAAA' ) { $r.IPAddress.RecordData.IPv6Address } else { $r.IPAddress.recorddata.IPv4Address } 
+					}
+				}
+			}
+		}
 	) | Sort-Object -Property NameServer
-	
+	#$global:saveRHS1 = $RHs
+
 	Write-Verbose "$(Get-Date): `t`tOutput DNS Server Settings for $DNSServerName"
 	$txt = "DNS Server Properties for $DNSServerName"
 	If($MSWord -or $PDF)
@@ -4308,7 +4340,8 @@ Function OutputDNSServer
 	
 	#Root Hints tab
 	Write-Verbose "$(Get-Date): `t`t`tRoot Hints"
-	
+	#$global:saveRHs = $RHs
+
 	#V1.11 Thanks to MBS, Root Hint servers are now sorted and processed more efficiently
 	
 	If($MSWord -or $PDF)

--- a/DNS_Inventory_V1.ps1
+++ b/DNS_Inventory_V1.ps1
@@ -442,7 +442,7 @@
 	NAME: DNS_Inventory.ps1
 	VERSION: 1.21
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: February 14, 2020
+	LASTEDIT: February 20, 2020
 #>
 
 #endregion
@@ -570,7 +570,7 @@ Param(
 #Version 1.00 released to the community on July 25, 2016
 
 #Version 1.21
-#	Fixed cases where no root hint servers were in the report or all the root hint servers were duplicated (MBS)
+#	Fixed by MBS: When the root hint IP address is an array, report on all entries of the array, instead of just the first entry
 
 #Version 1.20 13-Feb-2020
 #	Added -AllDNSServers (ALL) parameter to process all AD DNS servers that are online
@@ -3586,7 +3586,7 @@ Function ProcessScriptStart
 		If($Null -eq $AllServers)
 		{
 			#oops no DNS servers (which shouldn't happen in AD)
-			Write-Error "Unable to retrieve any DNS servers.  Script cannot continue"
+			Write-Error "Unable to retrieve any AD DNS servers. Script cannot continue."
 			Exit
 		}
 		Else

--- a/DNS_Inventory_V1_ReadMe.rtf
+++ b/DNS_Inventory_V1_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -93,10 +93,10 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid730732
 \rsid1120917\rsid2106581\rsid2388112\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid5177570\rsid5384286\rsid6634568\rsid7933527\rsid8261032\rsid8337971\rsid8742785\rsid8787618\rsid8814015\rsid9460937\rsid9517698\rsid9531606
-\rsid9844446\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12457768\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751
-\rsid14697282\rsid14893653\rsid15008361\rsid15343936\rsid15549553\rsid16019830\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
-{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo2\dy14\hr7\min27}{\version35}{\edmins199}{\nofpages15}{\nofwords4269}{\nofchars24338}{\nofcharsws28550}{\vern123}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/
-2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid9844446\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12279482\rsid12457768\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423
+\rsid14365751\rsid14697282\rsid14893653\rsid15008361\rsid15343936\rsid15549553\rsid16019830\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
+{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo2\dy20\hr14\min25}{\version36}{\edmins200}{\nofpages15}{\nofwords4269}{\nofchars24338}{\nofcharsws28550}{\vern123}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word
+/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NbE0NzA3NDWwMDE1NDVX0lEKTi0uzszPAykwqQUA5JLTdCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
@@ -207,13 +207,13 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f4e65058d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f4e65058d4d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296\hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
+\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=3929\hich\af37\dbch\af31505\loch\f37 6" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a004e7a1020}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a004e7a102046}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -221,7 +221,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000477f310300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000477f31030000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools f\hich\af43\dbch\af31505\loch\f43 or Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -737,7 +737,7 @@ ring>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DNS_Invento\hich\af2\dbch\af31505\loch\f2 ry.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8787618 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8787618 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12279482 \hich\af2\dbch\af31505\loch\f2 20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
 \hich\af2\dbch\af31505\loch\f2 , 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
@@ -1148,8 +1148,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c088
-d5733ae3d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000050f0
+54e32be8d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DNS_Inventory_V1_ReadMe.rtf
+++ b/DNS_Inventory_V1_ReadMe.rtf
@@ -1,20 +1,20 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f44\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\f45\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f46\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f48\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f49\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\f50\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f51\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f52\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\f53\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f65\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f66\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}{\f68\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}
-{\f69\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f70\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f71\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f72\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}
-{\f73\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f385\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f386\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f388\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}
-{\f389\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f392\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f393\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f415\fbidi \fswiss\fcharset238\fprq2 Calibri CE{\*\falt Calibri};}
-{\f416\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr{\*\falt Calibri};}{\f418\fbidi \fswiss\fcharset161\fprq2 Calibri Greek{\*\falt Calibri};}{\f419\fbidi \fswiss\fcharset162\fprq2 Calibri Tur{\*\falt Calibri};}
-{\f420\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew){\*\falt Calibri};}{\f421\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic){\*\falt Calibri};}{\f422\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic{\*\falt Calibri};}
-{\f423\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese){\*\falt Calibri};}{\f485\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f486\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f488\fbidi \froman\fcharset161\fprq2 Cambria Greek;}
-{\f489\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f492\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f493\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
+{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
+{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
+{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f64\fbidi \fmodern\fcharset238\fprq1 Courier New CE;}{\f65\fbidi \fmodern\fcharset204\fprq1 Courier New Cyr;}{\f67\fbidi \fmodern\fcharset161\fprq1 Courier New Greek;}
+{\f68\fbidi \fmodern\fcharset162\fprq1 Courier New Tur;}{\f69\fbidi \fmodern\fcharset177\fprq1 Courier New (Hebrew);}{\f70\fbidi \fmodern\fcharset178\fprq1 Courier New (Arabic);}{\f71\fbidi \fmodern\fcharset186\fprq1 Courier New Baltic;}
+{\f72\fbidi \fmodern\fcharset163\fprq1 Courier New (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}
+{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f414\fbidi \fswiss\fcharset238\fprq2 Calibri CE{\*\falt Calibri};}
+{\f415\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr{\*\falt Calibri};}{\f417\fbidi \fswiss\fcharset161\fprq2 Calibri Greek{\*\falt Calibri};}{\f418\fbidi \fswiss\fcharset162\fprq2 Calibri Tur{\*\falt Calibri};}
+{\f419\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew){\*\falt Calibri};}{\f420\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic){\*\falt Calibri};}{\f421\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic{\*\falt Calibri};}
+{\f422\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese){\*\falt Calibri};}{\f474\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\f475\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\f477\fbidi \froman\fcharset161\fprq2 Cambria Greek;}
+{\f478\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\f481\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\f482\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
 {\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
 {\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
 {\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -38,16 +38,16 @@
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
 \red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\red230\green230\blue230;\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp 
 \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 
-\rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 
-\rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{
-\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat 
+\rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 
+\rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat heading 1;}{
+\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat 
 heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
+\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\f44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
-\sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 
+\fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
+\sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \snext19 \sqformat \spriority1 \styrsid15549553 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat19 \sbasedon10 \ssemihidden \sunhideused \styrsid15343936 Unresolved Mention;}}{\*\listtable
 {\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }
@@ -92,22 +92,22 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid730732
-\rsid1120917\rsid2106581\rsid2388112\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid5177570\rsid5384286\rsid6634568\rsid7933527\rsid8261032\rsid8337971\rsid8742785\rsid8814015\rsid9460937\rsid9517698\rsid9531606\rsid9844446
-\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12457768\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14697282
-\rsid14893653\rsid15008361\rsid15343936\rsid15549553\rsid16019830\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo2\dy13\hr7\min29}{\version34}{\edmins198}{\nofpages15}{\nofwords4269}{\nofchars24338}{\nofcharsws28550}{\vern123}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid1120917\rsid2106581\rsid2388112\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid5177570\rsid5384286\rsid6634568\rsid7933527\rsid8261032\rsid8337971\rsid8742785\rsid8787618\rsid8814015\rsid9460937\rsid9517698\rsid9531606
+\rsid9844446\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11435092\rsid11488686\rsid11602030\rsid12196856\rsid12457768\rsid12916989\rsid12996213\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751
+\rsid14697282\rsid14893653\rsid15008361\rsid15343936\rsid15549553\rsid16019830\rsid16149376\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
+{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo2\dy14\hr7\min27}{\version35}{\edmins199}{\nofpages15}{\nofwords4269}{\nofchars24338}{\nofcharsws28550}{\vern123}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/
+2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NbE0NzA3NDWwMDE1NDVX0lEKTi0uzszPAykwqQUA5JLTdCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid14365751 \hich\af44\dbch\af31505\loch\f44 Microsoft D}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 
-\b\fs28\cf20\insrsid2388112 \hich\af44\dbch\af31505\loch\f44 NS}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11602030 \hich\af44\dbch\af31505\loch\f44  }{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 
-\hich\af44\dbch\af31505\loch\f44 Version 1}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid16149376 .}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid2388112 0}{\rtlch\fcs1 \ab\af44\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 
-\hich\af44\dbch\af31505\loch\f44  Documentation Script ReadMe
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid14365751 \hich\af43\dbch\af31505\loch\f43 Microsoft D}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf20\insrsid2388112 \hich\af43\dbch\af31505\loch\f43 NS}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11602030 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 
+\hich\af43\dbch\af31505\loch\f43 Version 1}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid16149376 .}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid2388112 0}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 
+\hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid2885388 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5384286\charrsid5384286 \hich\af37\dbch\af31505\loch\f37 
 NOTE: This script }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid2885388 \hich\af37\dbch\af31505\loch\f37 requires PowerShell V3 or later but best performance is obtained by using PowerShell V5.
@@ -115,11 +115,11 @@ NOTE: This script }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid2885388 \hich
 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid3630949 \hich\af37\dbch\af31505\loch\f37 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5384286\charrsid5384286 \hich\af37\dbch\af31505\loch\f37  supported.}{\rtlch\fcs1 \af37 
 \ltrch\fcs0 \f37\insrsid5384286\charrsid5384286 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af44\dbch\af31505\loch\f44 Support for non-English Versions of Microsoft Word
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 T}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 he script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Catalan}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid13310106 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13310106 \hich\af37\dbch\af31505\loch\f37 Chinese}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13310106\charrsid13987238 
@@ -137,8 +137,8 @@ NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid3630949 \h
 \f37\fs22\insrsid11488686 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid10290913 \page \hich\af44\dbch\af31505\loch\f44 What the Script Documents
-\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid10290913 \page \hich\af43\dbch\af31505\loch\f43 What the Script Documents
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f31506\fs22\insrsid2885388 \hich\af31506\dbch\af31505\loch\f31506 This script documents t}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 he following items:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid14365751 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls5\rin0\lin720\itap0\pararsid14365751 {\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14365751 \hich\af31506\dbch\af31505\loch\f31506 D}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2388112 \hich\af31506\dbch\af31505\loch\f31506 NS}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
@@ -191,13 +191,13 @@ NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid3630949 \h
 \par }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14365751\charrsid10290913 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913 
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913\charrsid10290913 
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11602030 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 
-\hich\af44\dbch\af31505\loch\f44 Prerequisites
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11602030 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 
+\hich\af43\dbch\af31505\loch\f43 Prerequisites
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 
 Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 \hich\af37\dbch\af31505\loch\f37 DNS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \hich\af37\dbch\af31505\loch\f37 , let us ensure we have the necessary requirements.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 12}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 or later }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 
 \hich\af37\dbch\af31505\loch\f37 DNS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37  server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 .
@@ -207,13 +207,13 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f4e6505}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff007300000000006f00652e00000000205f4e65058d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296\hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a004e7a10}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000002e00000000003a004e7a1020}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -221,8 +221,8 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000477f3103}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\fs22\ul\cf1\insrsid12196856 \hich\af44\dbch\af31505\loch\f44 Remote Server Administration Tools fo\hich\af44\dbch\af31505\loch\f44 r Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000000000005c0009080000380000000000477f310300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\fs22\ul\cf1\insrsid12196856 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools f\hich\af43\dbch\af31505\loch\f43 or Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
@@ -234,15 +234,15 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37  server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and PowerShell Version }{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid2388112 \hich\af37\dbch\af31505\loch\f37 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 .0.  The script was run on Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 8.1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 with RSAT, Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 
-\hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and Power\hich\af37\dbch\af31505\loch\f37 Shell 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 
+\hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  and Powe\hich\af37\dbch\af31505\loch\f37 rShell 4}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 
 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8261032 \hich\af37\dbch\af31505\loch\f37 and}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2850273 \hich\af37\dbch\af31505\loch\f37 
  Windows 10 with RSAT, Word 2013 and PowerShell 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af44\dbch\af31505\loch\f44 Script Usage
-\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
+\par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2388112\charrsid730732 \hich\af37\dbch\af31505\loch\f37 DNS}{\rtlch\fcs1 \ai\af37\afs22 
 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventor}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 y}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid5384286 \hich\af37\dbch\af31505\loch\f37 _V1}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -269,7 +269,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 01}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  is the name of a Server 2012 or later }{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 \hich\af37\dbch\af31505\loch\f37 DNS}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  server.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid730732 
-\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2388112 \hich\af37\dbch\af31505\loch\f37 DNS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -279,9 +279,9 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11488686 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid730732 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid730732 \page }{\rtlch\fcs1 \ab\af44\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid730732 \hich\af44\dbch\af31505\loch\f44 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid730732 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid730732 \hich\af43\dbch\af31505\loch\f43 
 Help Text
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8261032 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af44\hich\af44\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
+\par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8261032 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8261032\charrsid8261032 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid8742785 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 PS C:\\Webster> get-help .\\DNS_Inventory_V1.ps1 -full
 
@@ -303,40 +303,40 @@ ring>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785
 \ltrch\fcs0 \f2\fs18\insrsid8742785 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2     <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\DNS_Inventory_V1.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 DNS_Inventory_V1.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-AllDNSServers] [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8742785 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-Details] [-Dev] [-Folder <String>] [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8742785 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2     [-ScriptI\hich\af2\dbch\af31505\loch\f2 nfo] [-UserName <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-Cove\hich\af2\dbch\af31505\loch\f2 rPage <String>] [-Details] [-Dev] [-Folder <String>] [-Log]}{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2     [-ScriptInfo] [-UserName <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\DNS_Inventory_V1.ps1 [-HTML] [-AddDateTime] [-AllDNSServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Details] [-Dev] \hich\af2\dbch\af31505\loch\f2 
-[-Folder <String>] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\DNS_Inventory_V1.ps1 [-HTML] [-AddD\hich\af2\dbch\af31505\loch\f2 ateTime] [-AllDNSServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\DNS_Inventory_V1.ps1 [-PDF] [-AddDateTime] [-AllDNSServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid8742785 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-Com\hich\af2\dbch\af31505\loch\f2 
-panyPhone <String>] [-ComputerName <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-Compan\hich\af2\dbch\af31505\loch\f2 yEmail <String>] [-CompanyFax <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-ComputerName <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 <String>] [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] [-UserName}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid8742785 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2     <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-AllDNSServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 
-[-ComputerName <String>] [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 C:\\Webster\\DNS_Inventory_V1.ps1 [-Text] [-AddDateTime] [-AllDNSServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Details] [-Dev] [-Folder <String>] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsoft Word, PDF, formatted text or HTML.
-\par \hich\af2\dbch\af31505\loch\f2     Creates a document named DNS.docx\hich\af2\dbch\af31505\loch\f2  (or .PDF or .TXT or .HTML).
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of Microsoft DNS using Microsof\hich\af2\dbch\af31505\loch\f2 t Word, PDF, formatted text or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a document named DNS.docx (or .PDF or .TXT or .HTML).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF documents include a Cover Page, Table of Contents and Footer.
 \par 
@@ -735,9 +735,9 @@ panyPhone <String>] [-ComputerName <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DNS_Invento\hich\af2\dbch\af31505\loch\f2 ry.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.20
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8787618 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16019830 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8787618 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8742785\charrsid8742785 
 \hich\af2\dbch\af31505\loch\f2 , 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
@@ -1148,8 +1148,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000007022
-959871e2d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c088
+d5733ae3d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DNS_Script_ChangeLog.txt
+++ b/DNS_Script_ChangeLog.txt
@@ -5,6 +5,9 @@
 #http://www.CarlWebster.com
 #Created on February 10, 2016
 
+#Version 1.21
+#	Fixed cases where no root hint servers were in the report or all the root hint servers were duplicated (MBS)
+
 #Version 1.20 13-Feb-2020
 #	Added -AllDNSServers (ALL) parameter to process all AD DNS servers that are online
 #		Added text file (BadDNSServers_yyyy-MM-dd_HHmm.txt) of the AD DNS servers that 

--- a/DNS_Script_ChangeLog.txt
+++ b/DNS_Script_ChangeLog.txt
@@ -6,7 +6,7 @@
 #Created on February 10, 2016
 
 #Version 1.21
-#	Fixed cases where no root hint servers were in the report or all the root hint servers were duplicated (MBS)
+#	Fixed by MBS: When the root hint IP address is an array, report on all entries of the array, instead of just the first entry
 
 #Version 1.20 13-Feb-2020
 #	Added -AllDNSServers (ALL) parameter to process all AD DNS servers that are online


### PR DESCRIPTION
#Version 1.21
#	Fixed by MBS: When the root hint IP address is an array, report on all entries of the array, instead of just the first entry
