### PR TITLE
Final update for 2.03

### DIFF
--- a/DNS_Inventory_V2_ReadMe.rtf
+++ b/DNS_Inventory_V2_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -96,22 +96,22 @@ Footer Char;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\
 \leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
 \'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid280646\rsid730732\rsid995184\rsid1120917\rsid1209168
-\rsid1266074\rsid1332157\rsid2106581\rsid2388112\rsid2509531\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid4880174\rsid5177570\rsid5384286\rsid6438957\rsid6634568\rsid6645253\rsid7538075\rsid7933527\rsid8261032\rsid8337971
-\rsid8339579\rsid8469482\rsid8742785\rsid8787618\rsid8814015\rsid9460937\rsid9517698\rsid9531606\rsid9844446\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11091093\rsid11435092\rsid11481303\rsid11488686\rsid11602030\rsid12072617\rsid12196856
-\rsid12279482\rsid12457768\rsid12669606\rsid12916989\rsid12996213\rsid13008601\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14511311\rsid14697282\rsid14893653\rsid15008361\rsid15077742\rsid15343936
-\rsid15549553\rsid15628082\rsid15940426\rsid16019830\rsid16149376\rsid16326170\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo9\dy11\hr15\min6}{\version49}{\edmins268}{\nofpages17}{\nofwords4787}{\nofchars27290}{\nofcharsws32013}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid1266074\rsid1332157\rsid2106581\rsid2388112\rsid2509531\rsid2850273\rsid2885388\rsid3215964\rsid3294353\rsid3630949\rsid3830441\rsid4880174\rsid5177570\rsid5384286\rsid6312781\rsid6438957\rsid6634568\rsid6645253\rsid7538075\rsid7933527\rsid8261032
+\rsid8337971\rsid8339579\rsid8469482\rsid8742785\rsid8787618\rsid8814015\rsid9460937\rsid9517698\rsid9531606\rsid9844446\rsid10243667\rsid10290913\rsid10501518\rsid10757636\rsid11091093\rsid11435092\rsid11481303\rsid11488686\rsid11602030\rsid12072617
+\rsid12196856\rsid12214732\rsid12279482\rsid12457768\rsid12669606\rsid12916989\rsid12996213\rsid13008601\rsid13047550\rsid13133162\rsid13256488\rsid13310106\rsid13987238\rsid14306423\rsid14365751\rsid14511311\rsid14697282\rsid14893653\rsid15008361
+\rsid15077742\rsid15343936\rsid15549553\rsid15628082\rsid15940426\rsid16019830\rsid16149376\rsid16326170\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
+{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo2\dy18\hr6\min45}{\version50}{\edmins272}{\nofpages17}{\nofwords4789}{\nofchars27303}{\nofcharsws32028}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2
+003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NbE0NzA3NDWwMDE1NDVX0lEKTi0uzszPAykwNKkFAFgh1XwtAAAA}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11481303 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1332157 \chftnsep 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12214732 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11481303 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1332157 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12214732 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11481303 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1332157 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12214732 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11481303 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid1332157 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12214732 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\footerr \ltrpar \pard\plain \ltrpar\s23\qr \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\field{\*\fldinst {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11481303 \hich\af43\dbch\af31505\loch\f43  PAGE   \\* MERGEFORMAT }}{\fldrslt {\rtlch\fcs1 \af0 \ltrch\fcs0 
 \lang1024\langfe1024\noproof\insrsid11481303 \hich\af43\dbch\af31505\loch\f43 2}}}\sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid11481303 
@@ -225,13 +225,13 @@ At least one Windows 8 or later computer with the Remote Server Administration T
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid1209168\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field\flddirty{\*\fldinst 
 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000fe}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid1209168\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field\flddirty{\*\fldinst {\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharefi\hich\af37\dbch\af31505\loch\f37 le.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 \hich\af37\dbch\af31505\loch\f37 HYPERLINK "https://carlwebster.sharef\hich\af37\dbch\af31505\loch\f37 ile.com/d-s37209afb73dc48f497745924ed854226"}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid1209168 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000fe}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid1209168\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1209168 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\*\bkmkend _Hlk61325322}{\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15628082 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -239,7 +239,7 @@ At least one Windows 8 or later computer with the Remote Server Administration T
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15628082 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid15628082 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f003432750100000000a300742e000000005a6ef800}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f003432750100000000a300742e000000005a6ef80000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid15628082 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15628082\charrsid12196856 
 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -369,7 +369,7 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003700390031003000
-37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+37003500640034003500310066006300340031003500630061003800330065006300380039003500380062003300380035006100390035000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s791075d451fc415ca83ec8958b385a95}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid16326170\charrsid16326170 
 \par 
@@ -377,7 +377,7 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003300370032003000
-39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b9}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+39006100660062003700330064006300340038006600340039003700370034003500390032003400650064003800350034003200320036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003b9ef}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.sharefile.com/d-s37209afb73dc48f497745924ed854226}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid16326170\charrsid16326170 
 \par 
@@ -385,16 +385,16 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ed}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003edef}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies a computer used\hich\af2\dbch\af31505\loch\f2  to run the script against.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies a computer use\hich\af2\dbch\af31505\loch\f2 d to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to\hich\af2\dbch\af31505\loch\f2  determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made t\hich\af2\dbch\af31505\loch\f2 o determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default is localhost.
@@ -604,14 +604,14 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax used for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposur\hich\af2\dbch\af31505\loch\f2 e (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
@@ -619,13 +619,13 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name used for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyN\hich\af2\dbch\af31505\loch\f2 ame or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par 
@@ -724,8 +724,8 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
+\par \hich\af2\dbch\af31505\loch\f2         Required?    \hich\af2\dbch\af31505\loch\f2                 false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -734,51 +734,51 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         Default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default is False.
+\par \hich\af2\dbch\af31505\loch\f2         Specif\hich\af2\dbch\af31505\loch\f2 ies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    nam\hich\af2\dbch\af31505\loch\f2 ed
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpS\hich\af2\dbch\af31505\loch\f2 erver is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parame\hich\af2\dbch\af31505\loch\f2 ters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2     <CommonPara\hich\af2\dbch\af31505\loch\f2 meters>
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=11
-\hich\af2\dbch\af31505\loch\f2 3216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00039c}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab00039c00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None. You cannot pipe objects to this script.
@@ -793,16 +793,17 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DNS_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.02
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.0}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR\hich\af2\dbch\af31505\loch\f2 : Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1266074 \hich\af2\dbch\af31505\loch\f2 September 11, 2021}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781 \hich\af2\dbch\af31505\loch\f2 Februa\hich\af2\dbch\af31505\loch\f2 ry 18, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -869,14 +870,14 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Tests to see if the computer, localhost, is a DNS server.
 \par \hich\af2\dbch\af31505\loch\f2     If it is, the script runs. If not, the script aborts.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML do\hich\af2\dbch\af31505\loch\f2 cument.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an HTML document.
 \par 
 \par 
 \par 
@@ -886,7 +887,7 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1 -ComputerName localhost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script resolves localhost to $env:computername, for example, DNSServer01.
-\par \hich\af2\dbch\af31505\loch\f2     The script runs remot\hich\af2\dbch\af31505\loch\f2 ely against the DNS server DNSServer01 and not localhost.
+\par \hich\af2\dbch\af31505\loch\f2     The script runs remotely agai\hich\af2\dbch\af31505\loch\f2 nst the DNS server DNSServer01 and not localhost.
 \par \hich\af2\dbch\af31505\loch\f2     The output filename uses the server name DNSServer01 and not localhost.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates an HTML file.
@@ -925,15 +926,15 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_\hich\af2\dbch\af31505\loch\f2 Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DNS_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -ComputerName DNSServer02 -Details -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Carl Webster for the Username (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the Username (alias UN).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script runs remotely against the DNS server DNSServer02.
+\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript runs remotely against the DNS server DNSServer02.
 \par \hich\af2\dbch\af31505\loch\f2     The output contains DNS Resource Record information.
 \par 
 \par 
@@ -941,13 +942,13 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PS\hich\af2\dbch\af31505\loch\f2 Script >.\\DNS_Inventory_V2.ps1 -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1 -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date Timestamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a d\hich\af2\dbch\af31505\loch\f2 ate Timestamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     July 25, 2021 at 6PM is 2021-07-25_1800.
-\par \hich\af2\dbch\af31505\loch\f2     The output filename is DNS Inventory Report for Serv\hich\af2\dbch\af31505\loch\f2 er <server> for the Domain
-\par \hich\af2\dbch\af31505\loch\f2     <domain>_2021-07-25_1800.html.
+\par \hich\af2\dbch\af31505\loch\f2     The output filename is DNS Inventory Report for Server <server> for the Domain
+\par \hich\af2\dbch\af31505\loch\f2     <domain>_2021-07-25_1800.h\hich\af2\dbch\af31505\loch\f2 tml.
 \par 
 \par 
 \par 
@@ -1029,14 +1030,16 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates four reports: HTML, Microsoft Word, PDF, and plain text.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DNSInventoryScriptErrors_yyyy-MM-dd_HHmm for the Domain
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DNSInventoryScriptErrors_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781\charrsid6312781 \hich\af2\dbch\af31505\loch\f2 yyyyMMddTHHmmssffff}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2  for the Domain
 \par \hich\af2\dbch\af31505\loch\f2     <domain>.txt that contains up to the last 2\hich\af2\dbch\af31505\loch\f2 50 errors reported by the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DNSInventoryScriptInfo_yyyy-MM-dd_HHmm for the Domain
 \par \hich\af2\dbch\af31505\loch\f2     <domain>.txt that contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging nam\hich\af2\dbch\af31505\loch\f2 ed
-\par \hich\af2\dbch\af31505\loch\f2     DNSDocScriptTranscript_yyyy-MM-dd_HHmm for the Domain <domain>.txt.
+\par \hich\af2\dbch\af31505\loch\f2     DNSDocScriptTranscript_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781\charrsid6312781 \hich\af2\dbch\af31505\loch\f2 yyyyMMddTHHmmssffff}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2  for the Domain <domain>.txt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Microsoft Word and PDF, uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1063,7 +1066,8 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 email,
 \par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1088,20 +1092,20 @@ DNS_In\hich\af2\dbch\af31505\loch\f2 ventory_V2.ps1 [-ComputerName <String>] [-A
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030077}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERL\hich\af2\dbch\af31505\loch\f2 INK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPER\hich\af2\dbch\af31505\loch\f2 LINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030072}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  account.
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonym\hich\af2\dbch\af31505\loch\f2 ous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
 \par 
@@ -1113,21 +1117,19 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-off\hich\af2\dbch\af31505\loch\f2 ice-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 
-{\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
+\hich\af2\dbch\af31505\loch\f2 -a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-\hich\af2\dbch\af31505\loch\f2 
-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00037f00}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
+}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16326170\charrsid16326170 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example*\hich\af2\dbch\af31505\loch\f2 **
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.ma\hich\af2\dbch\af31505\loch\f2 il.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
 \par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
@@ -1135,15 +1137,16 @@ us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-app
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 20 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending \hich\af2\dbch\af31505\loch\f2 from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the emai\hich\af2\dbch\af31505\loch\f2 l server smtp.office365.com on port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1152,17 +1155,18 @@ us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-app
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DNS_Inventory_V2.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.co\hich\af2\dbch\af31505\loch\f2 m -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send em\hich\af2\dbch\af31505\loch\f2 ail using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, send\hich\af2\dbch\af31505\loch\f2 ing to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com o\hich\af2\dbch\af31505\loch\f2 n port 587 using SSL,
+\par \hich\af2\dbch\af31505\loch\f2     sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6312781 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16326170\charrsid16326170 \hich\af2\dbch\af31505\loch\f2 email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
 \par 
 \par 
@@ -1286,8 +1290,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000009060
-5a8748a7d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000901e
+7f59c524d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DNS_Script_ChangeLog.txt
+++ b/DNS_Script_ChangeLog.txt
@@ -5,6 +5,23 @@
 #http://www.CarlWebster.com
 #Created on February 10, 2016
 
+#Version 2.03 18-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 2.02 11-Sep-2021
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables
 #	Added Function OutputReportFooter


### PR DESCRIPTION
#Version 2.03 18-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file